### PR TITLE
Fixing Links, Changelog and Footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### PULSE V2 IS OUT
 
-Please read the [changelog](https://pulsejs.org/introduction/changelog.html) to ensure your old code is compatible.
+Please read the [changelog](https://pulsejs.org/v2/introduction/changelog.html) to ensure your old code is compatible.
 
 Pulse is an application logic library for reactive Javascript frameworks with support for VueJS, React and React Native. Lightweight, modular and powerful, but most importantly easy to understand.
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -91,7 +91,8 @@ module.exports = {
           collapsable: false,
           children: [
             // These are pages we'll add later
-            'introduction/what-is-pulse'
+            'introduction/what-is-pulse',
+            'introduction/changelog'
           ]
         },
         {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -11,7 +11,7 @@ module.exports = {
     logo: '/logo.svg',
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Guide', link: '/v2/' }
+      { text: 'Guide', link: '/v2/introduction/what-is-pulse.html' }
     ],
     lastUpdated: 'Last Updated',
     // Assumes GitHub. Can also be a full GitLab url.

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,4 +1,4 @@
-export default ({ Vue, router}) => {
+export default ({ Vue }) => {
     Vue.mixin({
       computed: {
         versions() {
@@ -14,13 +14,12 @@ export default ({ Vue, router}) => {
           else {
             return true
           }
-        },
+        }
+      },
+      data() {
+        return{
+          firstpage: '/introduction/what-is-pulse.html'
+        }
       }
-    }),
-    router.addRoutes([
-      { path: '/v1.html', redirect: '/v1/introduction/what-is-pulse' },
-      { path: '/v1', redirect: '/v1/introduction/what-is-pulse' },
-      { path: '/v2.html', redirect: '/v2/introduction/what-is-pulse' },
-      { path: '/v2', redirect: '/v2/introduction/what-is-pulse' },
-    ])
+    })
 }

--- a/docs/.vuepress/theme/components/VersionDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionDropdown.vue
@@ -18,8 +18,7 @@ export default {
   methods: {
     getVer,
     changedocs(url){
-      location.pathname = url
-      this.$router.push(url)
+      location.pathname = url+this.firstpage
     }
   },
   mounted() {

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,7 +13,7 @@ footer: MIT Licensed | Copyright © 2019 - Jamie Pine
   <a href="https://npmjs.com/pulse-framework"><img src="https://img.shields.io/npm/dm/pulse-framework.svg" alt="NPM Monthly Downloads"></a>
   <a href="https://npmjs.com/pulse-framework"><img src="https://img.shields.io/npm/dw/pulse-framework.svg" alt="NPM Weekly Downloads"></a>
   <a href="https://npmjs.com/pulse-framework"><img src="https://img.shields.io/npm/dt/pulse-framework.svg" alt="NPM Total Downloads"></a>
-  <a href="https://npmjs.com/pulse-framework"><img src="https://img.shields.io/bundlephobia/min/pulse-framework.svg" alt="NPM Bundle MIN Size"></a>
+  <a href="https://npmjs.com/pulse-framework"><img src="https://img.shields.io/bundlephobia/min/pulse.svg" alt="NPM Bundle MIN Size"></a>
   <a href="https://github.com/jamiepine/pulse"><img src="https://img.shields.io/github/license/jamiepine/pulse.svg" alt="GitHub License"></a>
   <a href="https://github.com/jamiepine/pulse"><img src="https://img.shields.io/github/languages/code-size/jamiepine/pulse.svg" alt="GitHub Code Size"></a>
   <a href="https://github.com/jamiepine/pulse"><img src="https://img.shields.io/github/repo-size/jamiepine/pulse.svg" alt="GitHub Repo Size"></a>

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,7 +2,7 @@
 home: true
 actionText: Getting Started →
 actionLink: /v2/introduction/what-is-pulse
-footer: MIT Licensed | Copyright © 2018 - Jamie Pine
+footer: MIT Licensed | Copyright © 2019 - Jamie Pine
 ---
 
 <p align="center">

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,7 @@
 ---
 home: true
 actionText: Getting Started →
-actionLink: /v2/
+actionLink: /v2/introduction/what-is-pulse
 footer: MIT Licensed | Copyright © 2018 - Jamie Pine
 ---
 

--- a/docs/v2/introduction/changelog.md
+++ b/docs/v2/introduction/changelog.md
@@ -1,3 +1,7 @@
+---
+title: Changelog
+---
+
 # 2.0 - Internal rewrite
 
 Pulse version two is a complete ground-up rewrite. For the most part it should not affect your code, it is indeed backwards compatible. However there are a few things that have changed externally that you should know about before updating to V2.


### PR DESCRIPTION
# Navbar + Dropdown Links, Sidebar and Misc

> Navbar + Dropdown done in a more hard-coded way

<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
Instead of using vue-router to try and handle redirects and the previous shenanigans, the "firstpage" (the page you want to see first) for each version is a global data export in `enhanceApp.js`, one potential downside to this is that every future first page needs to exist at `(whatever version)/introduction/what-is-pulse.html`.
The changelog file will now appear in the sidebar for V2, I plan on having this exist in the navbar separate from versions in the future, but for now this is more focused on having the docs work.

## Misc
Bundlephobia badge fixed by changing `/pulse-framework.svg` to `/pulse.svg`
Footer year now reads 2019
