### PR TITLE
Fix Bundlephobia Error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["@babel/preset-env"],
-  "plugins": [["@babel/plugin-transform-runtime", {"helpers": true,"regenerator": true}]]
+  "plugins": [["@babel/plugin-transform-runtime"]]
 }

--- a/build/rollup.dev.config.js
+++ b/build/rollup.dev.config.js
@@ -4,7 +4,7 @@ import replace from 'rollup-plugin-replace';
 import babel from 'rollup-plugin-babel';
 import typescript from 'rollup-plugin-typescript';
 
-const prod = process.env.PRODUCTION;
+const prod = process.env.NODE_ENV === 'production';
 
 export default {
   input: './lib/index.ts',

--- a/build/rollup.dev.config.js
+++ b/build/rollup.dev.config.js
@@ -10,21 +10,21 @@ export default {
   input: './lib/index.ts',
   output: [
     {
-      file: 'dist/pulse.min.js',
+      file: 'dist/pulse.js',
       name: 'Pulse',
       format: 'umd',
       freeze: false,
       sourcemap: true
     },
     {
-      file: 'dist/pulse.cjs.min.js',
+      file: 'dist/pulse.cjs.js',
       name: 'Pulse',
       format: 'cjs',
       freeze: false,
       sourcemap: true
     },
     {
-      file: 'dist/pulse.esm.min.js',
+      file: 'dist/pulse.esm.js',
       name: 'Pulse',
       format: 'esm',
       sourcemap: true

--- a/build/rollup.prod.config.js
+++ b/build/rollup.prod.config.js
@@ -11,21 +11,21 @@ export default {
   input: './lib/index.ts',
   output: [
     {
-      file: 'dist/pulse.min.js',
+      file: 'dist/pulse.js',
       name: 'Pulse',
       format: 'umd',
       freeze: false,
       sourcemap: true
     },
     {
-      file: 'dist/pulse.cjs.min.js',
+      file: 'dist/pulse.cjs.js',
       name: 'Pulse',
       format: 'cjs',
       freeze: false,
       sourcemap: true
     },
     {
-      file: 'dist/pulse.esm.min.js',
+      file: 'dist/pulse.esm.js',
       name: 'Pulse',
       format: 'esm',
       sourcemap: true

--- a/build/rollup.prod.config.js
+++ b/build/rollup.prod.config.js
@@ -5,7 +5,7 @@ import replace from 'rollup-plugin-replace';
 import babel from 'rollup-plugin-babel';
 import typescript from 'rollup-plugin-typescript';
 
-const prod = process.env.PRODUCTION;
+const prod = process.env.NODE_ENV === 'production';
 
 export default {
   input: './lib/index.ts',

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 
 module.exports =
   process.env.NODE_ENV === 'production'
-    ? require('./dist/pulse.min.js')
-    : require('./dist/pulse.min.js');
+    ? require('./dist/pulse.js')
+    : require('./dist/pulse.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10276,6 +10276,25 @@
         "inherits": "^2.0.1"
       }
     },
+    "rollup": {
+      "version": "1.27.14",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.14.tgz",
+      "integrity": "sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        }
+      }
+    },
     "rollup-plugin-babel": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "pulse-framework",
   "version": "2.2.0",
   "description": "Global state and logic framework for reactive Javascript applications.",
-  "main": "dist/pulse.min.js",
-  "module": "dist/pulse.esm.min.js",
+  "main": "dist/pulse.js",
+  "module": "dist/pulse.esm.js",
   "scripts": {
     "test": "mocha --exit",
     "test-debug": "mocha --inspect-brk",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-prettier": "^4.0.0",
     "jest": "^24.7.1",
     "prettier": "1.16.3",
+    "rollup": "^1.27.14",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-livereload": "^1.0.1",

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,4 +1,4 @@
-const Pulse = require('../dist/pulse.min.js');
+const Pulse = require('../dist/pulse.js');
 const assert = require('assert');
 const { expect } = require('chai');
 

--- a/test/debouce.test.js
+++ b/test/debouce.test.js
@@ -1,4 +1,4 @@
-const Pulse = require('../dist/pulse.min.js');
+const Pulse = require('../dist/pulse.js');
 const assert = require('assert');
 const {expect} = require('chai');
 

--- a/test/deepReactive.js
+++ b/test/deepReactive.js
@@ -1,4 +1,4 @@
-const Pulse = require('../dist/pulse.min.js');
+const Pulse = require('../dist/pulse.js');
 const assert = require('assert');
 const { expect } = require('chai');
 console.clear();

--- a/test/mapData.test.js
+++ b/test/mapData.test.js
@@ -1,4 +1,4 @@
-const Pulse = require('../dist/pulse.min.js');
+const Pulse = require('../dist/pulse.js');
 const assert = require('assert');
 const { expect } = require('chai');
 console.clear();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceMap": true,
     "allowJs": true,
     "lib": ["es7", "dom", "es2017"],
-    "rootDir": "v1",
     "moduleResolution": "node"
-  }
+  },
+  "include": ["./lib/**/*"]
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fixes a case where Webpack's configuration is set to not parse minified files, for example:
`noParse: [/\.min\.js/]`
## Description
<!--- Please describe all your changes in detail -->
- Added Rollup as devDependency
- Changed Rollup config files to output bundled files without .min extension
- Fixed other references to the previous ".min" file
## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please provide a link to the issue here: -->
#43 
## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->
[bundleophobia](https://github.com/pastelsky/bundlephobia)'s webpack configuration is currently set to not parse ".min" files:

https://github.com/pastelsky/package-build-stats/blob/617df97ed51cb8c91d57d7aed19a4a9da7506825/src/webpack.config.js#L83

Also, Pulse's current Rollup configs don't bundle to minified version either which in my opinion is the way to go since large portion of users handle bundling and minification on their own in production, with for example Webpack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
Tested with local build of @pastelsky's [package-build-stats](https://github.com/pastelsky/package-build-stats) which powers the core of Bundlephobia
