### PR TITLE
Update modules.md

### DIFF
--- a/docs/v2/docs/modules.md
+++ b/docs/v2/docs/modules.md
@@ -111,8 +111,8 @@ Components can use computed functions without needing to re-compute that compute
 channels: {
   groups: ['subscribed'],
   computed: {
-    liveChannels({ groups }) => {
-      return groups.subscribed.filter(channel => channel.live === true)
+    liveChannels({ channels }) => {
+      return channels.subscribed.filter(channel => channel.live === true)
     }
   }
 }


### PR DESCRIPTION
`groups.groupName` returns `undefined` in Pulse 2.2.3 in a computed function

<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please provide a link to the issue here: -->

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
