### PR TITLE
Added a trycatch for the JSON.parse in the storage

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -61,7 +61,15 @@ export default class Storage {
           .catch(reject);
       });
     } else {
-      return JSON.parse(this.storageMethods.get(this.getKey(key)));
+      /**
+       * @itsRems - 3/23/20
+       * Added a trycatch to avoid an "unexpected error" when used outside of a Promise - There might be a better way to do this but it fixes the problem for now
+       */
+      try {
+        return JSON.parse(this.storageMethods.get(this.getKey(key)));
+      } catch (error) {
+        return undefined;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Added a trycatch that returns undefined on catch in the non-promise part of the storage's get function. This allows for undefined to be returned in case the storage value is undefined.

## Context
This fixes an issue with NextJS production builds that would simply return an unexpected error when trying to parse "undefined", causing the entire page's content to be replaced by this error.

## How Has This Been Tested?
I've used this change in both dev & production fo NextJS (SSR & Non-SSR) environnements with no issue.
