### PR TITLE
Fixed an issue where the content-type header would be present twice.

### DIFF
--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -15,8 +15,23 @@ export interface apiConfig {
   responseIntercept?: Function;
 }
 
+const ensureProperHeaders = (headers) => {
+  let newHeaders = {};
+  Object.keys(headers).forEach(key => {
+    const value = headers[key];
+    newHeaders[key.toLowerCase()] = value;
+  })
+  return newHeaders;
+}
+
 export default class API {
   constructor(public config: apiConfig = { options: {} }) {
+    /**
+     * Make all headers lowerCase
+     */
+    if (config.options && config.options.headers) {
+      config.options.headers = ensureProperHeaders(config.options.headers);
+    } 
     if (!config.options) config.options = {};
   }
 
@@ -26,9 +41,12 @@ export default class API {
    */
   public with(config: apiConfig): API {
     let _this = { ...this };
+    if (config.options && config.options.headers) {
+      config.options.headers = ensureProperHeaders(config.options.headers);
+    }
     _this.config = {
       ..._this.config,
-      ...config
+      ...config,
     };
     return _this;
   }

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -35,6 +35,17 @@ export default class API {
     if (!config.options) config.options = {};
   }
 
+  set (config: apiConfig) {
+    const conf = this.config;
+    if (config.options && config.options.headers) {
+      config.options.headers = ensureProperHeaders(config.options.headers);
+    }
+    this.config = {
+      ...conf,
+      ...config
+    }
+  }
+
   /**
    * Override API config and request options. Returns a modified instance this API with overrides applied.
    * @param config - O

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -35,17 +35,6 @@ export default class API {
     if (!config.options) config.options = {};
   }
 
-  set (config: apiConfig) {
-    const conf = this.config;
-    if (config.options && config.options.headers) {
-      config.options.headers = ensureProperHeaders(config.options.headers);
-    }
-    this.config = {
-      ...conf,
-      ...config
-    }
-  }
-
   /**
    * Override API config and request options. Returns a modified instance this API with overrides applied.
    * @param config - O


### PR DESCRIPTION
## Description
This fixes an issue where if the user was to set headers with upper cases (like "Content-Type"), pulse would re-add the "content-type" header (notice the lowercase) upon sending a request. This would then caused the "content-type" header to have "application/json, application/json" as a value instead of "application/json". This if fixed by ensuring that all headers that are set upon the creation of an api instance all get they keys to be lower-cased.

## How Has This Been Tested?
This has been tested with a sample NextJS App sending requests to a dummy express API with a bodyParser.json middleware.

## Warning
If you try to change a header on the go, the same issue will happen (due to the base headers being set to be lowercase). **IT IS RECOMMENDED TO ONLY USE LOWER-CASED HEADER KEYS FOR USAGE WITHIN PULSE**