### PR TITLE
Fixed resetState()

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,10 +11,10 @@ export function cleanState(state: State): any {
   };
 }
 
-function resetState(items: Array<State | Collection | any>) {
+export function resetState(items: Array<State | Collection | any>) {
   items.forEach(item => {
     if (item instanceof Collection) item.reset();
-		if (item instanceof State) return item.reset();
+    if (item instanceof State) return item.reset();
     const stateSet = extractAll(item, State);
     stateSet.forEach(state => state.reset());
   });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,9 +11,10 @@ export function cleanState(state: State): any {
   };
 }
 
-export function resetState(items: Array<State | Collection | any>) {
+function resetState(items: Array<State | Collection | any>) {
   items.forEach(item => {
     if (item instanceof Collection) item.reset();
+		if (item instanceof State) return item.reset();
     const stateSet = extractAll(item, State);
     stateSet.forEach(state => state.reset());
   });


### PR DESCRIPTION
Fixed a bug where the extractAll function would crash when encountering a state inside the reset array.
Simply fixed by doing return item.reset() if the item is a State
