### PR TITLE
Move computeValue into a proper function

### DIFF
--- a/lib/computed.ts
+++ b/lib/computed.ts
@@ -14,18 +14,18 @@ export class Computed<ComputedValueType = any> extends State<ComputedValueType> 
     super(instance, instance().config.computedDefault || null);
 
     if (deps) deps.forEach((state) => state.dep.depend(this));
-
-    this.computeValue = () => {
-      if (deps) return func();
-      instance().runtime.trackState = true;
-      const computed = func();
-      let dependents = instance().runtime.getFoundState();
-      dependents.forEach((state) => state.dep.depend(this));
-      return computed;
-    };
+    const output = this.computeValue();
 
     // const output = this.computeValue();
     // this.set(output);
+  }
+  private computeValue() {
+    if (this.deps) return this.func();
+    this.instance().runtime.trackState = true;
+    const computed = this.func();
+    let dependents = this.instance().runtime.getFoundState();
+    dependents.forEach((state) => state.dep.depend(this));
+    return computed;
   }
   public recompute(): void {
     this.set(this.computeValue());

--- a/lib/computed.ts
+++ b/lib/computed.ts
@@ -1,4 +1,4 @@
-import State, { reset } from './state';
+import State, { reset, SetFunc } from './state';
 import Pulse from './pulse';
 import Dep from './dep';
 
@@ -19,7 +19,7 @@ export class Computed<ComputedValueType = any> extends State<ComputedValueType> 
     // const output = this.computeValue();
     // this.set(output);
   }
-  private computeValue() {
+  private computeValue(): ComputedValueType | SetFunc<ComputedValueType> {
     if (this.deps) return this.func();
     this.instance().runtime.trackState = true;
     const computed = this.func();

--- a/lib/computed.ts
+++ b/lib/computed.ts
@@ -19,7 +19,7 @@ export class Computed<ComputedValueType = any> extends State<ComputedValueType> 
     // const output = this.computeValue();
     // this.set(output);
   }
-  private computeValue(): ComputedValueType | SetFunc<ComputedValueType> {
+  public computeValue(): ComputedValueType | SetFunc<ComputedValueType> {
     if (this.deps) return this.func();
     this.instance().runtime.trackState = true;
     const computed = this.func();

--- a/lib/runtime.ts
+++ b/lib/runtime.ts
@@ -21,7 +21,12 @@ export default class Runtime {
     let job: Job = { state, newState };
     // grab nextState if newState not passed, compute if needed
     if (arguments[1] === undefined) {
-      job.newState = job.state.computeValue ? job.state.computeValue(job.state.nextState) : job.state.nextState;
+
+      job.newState = job.state instanceof Computed
+        // if computed, recompute value
+        ? job.state.computeValue()
+        // otherwise, default to nextState
+        : job.state.nextState;
     }
 
     this.queue.push(job);

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -23,8 +23,6 @@ export class State<ValueType = any> {
   public valueType?: string;
   // sideEffects can be set by extended classes, such as Groups to build their output.
   public sideEffects?: Function;
-  // computeValue is the method to return a new value. it is undefined in State but can be used by extended classes such as Computed, which creates it's own value
-  public computeValue?: (newState?: ValueType) => ValueType;
 
   public set bind(value: ValueType) {
     this.set(value);

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -239,4 +239,4 @@ export function reset(instance: State) {
   if (instance.persistState) instance.instance().storage.remove(instance.name);
 }
 
-type SetFunc<ValueType> = (state: ValueType) => ValueType;
+export type SetFunc<ValueType> = (state: ValueType) => ValueType;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
This makes the code a lil bit cleaner by not setting an undeclared instance variable to an ArrowFunction.

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please provide a link to the issue here: -->
I didn't think it was a very nice way to do it and Jamie seemed to agree. That's the issue lol

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->
The code looks cooler and is properly typed now, because I'm cool and properly typed now

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
TypeScript didn't error and Jamie agreed. I think that's the extent of it?