### PR TITLE
Clean up after extractAll changes, clean up formatting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": [["@babel/plugin-transform-runtime"]]
+  "presets": [
+    "@babel/preset-env"
+  ],
+  "plugins": [
+    ["@babel/plugin-transform-runtime"]
+  ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,7 @@
   "jsxBracketSameLine": false,
   "noSemi": false,
   "rcVerbose": true,
-  "ignoreChainWithDepth": 10
+  "ignoreChainWithDepth": 10,
+  "arrowParens": "avoid",
+  "semi": true
 }

--- a/lib/next/index.ts
+++ b/lib/next/index.ts
@@ -5,8 +5,8 @@ export function preserveServerState(
   nextProps: { [key: string]: any },
   core: { [key: string]: any }
 ) {
-  const collections = extractAll<Collection>(core, Collection);
-  const state = extractAll<State>(core, State);
+  const collections = extractAll(Collection, core);
+  const state = extractAll(State, core);
 
   const PULSE_DATA = {
     collections: [],
@@ -40,8 +40,8 @@ export function loadServerState(core: { [key: string]: any }) {
   if (globalThis?.__NEXT_DATA__?.props?.pageProps?.PULSE_DATA) {
     const pulseData = globalThis.__NEXT_DATA__.props.pageProps.PULSE_DATA
 
-    const state = extractAll<State>(core, State);
-  const collections = extractAll<Collection>(core, Collection);
+    const state = extractAll(State, core);
+    const collections = extractAll(Collection, core);
 
     state.forEach(item => {
       if (item.name && pulseData.state[item.name]) 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,7 +16,7 @@ export function resetState(items: Array<State | Collection | any>) {
   items.forEach((item) => {
     if (item instanceof Collection) item.reset();
     if (item instanceof State) return item.reset();
-    const stateSet = extractAll(item, State);
+    const stateSet = extractAll(State, item);
     stateSet.forEach((state) => state.reset());
   });
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs --dest ./docs/dist/",
     "now-build": "yarn run docs:build",
-    "postinstall": "tsc --noEmit"
+    "postinstall": "tsc"
   },
   "types": "./dist/index.d.ts",
   "author": "Jamie Pine",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "tsc-watch",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs --dest ./docs/dist/",
-    "now-build": "npm run docs:build",
+    "now-build": "yarn run docs:build",
     "postinstall": "tsc --noEmit"
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs --dest ./docs/dist/",
     "now-build": "npm run docs:build",
-    "postinstall": "tsc"
+    "postinstall": "tsc --noEmit"
   },
   "types": "./dist/index.d.ts",
   "author": "Jamie Pine",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
- Fixed a few instances of `extractAll` to use the updates argument order 
- ~~Don't compile the library every time you install a package with yarn~~ Jamie said this is intentional until we figure out a nicer way
- Cleaned up some formatting, including an update to `.prettierrc` to keep formatting consistent
  - (because I don't write the same way Jamie seems to... I use tabs, no semis, all that goodness. oops!)
- Removed Herobrine

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->
- Some `extractAll` instances would break due to having opposite-of-intended usage
- Some code formatting was slightly mind-boggling in my opinion
- Herobrine kept spawning when I was trying to kill the wither

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
- Well, it didn't error, and...
- fun fact: I'm actually writing unit tests and have them on the way!