### PR TITLE
Fixed PulseHOC 

### DIFF
--- a/lib/pulse.ts
+++ b/lib/pulse.ts
@@ -53,7 +53,7 @@ export default class Pulse {
   private core: { [key: string]: any } = {};
 
   constructor(public config: PulseConfig = defaultConfig) {
-    this.subController = new SubController();
+    this.subController = new SubController(this);
     this.status = new StatusTracker(() => this);
     this.runtime = new Runtime(() => this);
     this.storage = new Storage(() => this, config.storage || {});

--- a/lib/sub.ts
+++ b/lib/sub.ts
@@ -2,108 +2,121 @@
 // This class handles external components subscribing to Pulse.
 
 import Pulse from '.';
-import { State } from './';
-import { genId } from './utils';
+import {State} from './';
 
 export type SubscriptionContainer = ComponentContainer | CallbackContainer;
 
 export interface SubscribingComponentObject {
-  componentUUID: string;
-  keys: Array<string>;
+	componentUUID: string;
+	keys: Array<string>;
 }
 
 export class ComponentContainer {
-  public keysChanged: Array<string>; // used to preserve local keys to update before update is performed, cleared every update
-  public ready: boolean = true;
-  public passProps: boolean = false;
-  public mappedStates?: { [key: string]: State };
-  constructor(public instance: any, public subs?: Set<State>) {}
+	public keysChanged: Array<string> = []; // used to preserve local keys to update before update is performed, cleared every update
+	public ready: boolean = true;
+	public passProps: boolean = false;
+	public mappedStates?: { [key: string]: State };
+
+	constructor(public instance: any, public subs: Set<State> = new Set<State>([])) {
+	}
 }
 
 export class CallbackContainer extends ComponentContainer {
-  constructor(public callback: Function, public subs?: Set<State>) {
-    super(null);
-  }
+	constructor(public callback: Function, subs?: Set<State>) {
+		super(null, subs);
+	}
 }
 
 export default class SubController {
-  public components: Set<ComponentContainer> = new Set();
-  public callbacks: Set<CallbackContainer> = new Set();
+	public pulseInstance;
 
-  constructor() {}
+	public components: Set<ComponentContainer> = new Set();
+	public callbacks: Set<CallbackContainer> = new Set();
 
-  /**
-   * Subscribe to Pulse state WITH return object
-   */
-  public mapToProps(
-    instance: any,
-    subs: { [key: string]: State } = {}
-  ): { [key: string]: State['value'] } {
-    let cC = this.registerComponent(instance);
-    let returnProps = {};
-    cC.passProps = true;
-    cC.mappedStates = { ...subs };
+	constructor(pulseInstance: Pulse) {
+		this.pulseInstance = pulseInstance;
+	}
 
-    let localKeys = Object.keys(subs);
-    localKeys.forEach(key => {
-      let state = subs[key];
-      if (state instanceof State) {
-        cC.subs.add(state);
-        state.dep.subs.add(cC);
-        returnProps[key] = state.value;
-      }
-    });
+	/**
+	 * Subscribe to Pulse with a returned array of props this props can than passed trough the component (See react-integration)
+	 */
+	public subscribeWithSubsObject(subscriptionInstance: any, subs: { [key: string]: State } = {}): { subscriptionContainer: SubscriptionContainer, props: { [key: string]: State['value'] } } {
+		// Register Component
+		const subscriptionContainer = this.registerComponent(subscriptionInstance);
 
-    return { cC, props: returnProps };
-  }
+		const props: { [key: string]: State } = {};
+		subscriptionContainer.passProps = true;
+		subscriptionContainer.mappedStates = {...subs};
 
-  /**
-   * Subscribe to Pulse state WITHOUT return object
-   */
-  public subscribe(instance: any, subs: Array<State> = []): SubscriptionContainer {
-    let cC = this.registerComponent(instance, subs);
-    subs.forEach(state => {
-      if (state instanceof State) {
-        cC.subs.add(state);
-        state.dep.subs.add(cC);
-      }
-    });
-    return cC;
-  }
+		// Go through subs
+		let localKeys = Object.keys(subs);
+		localKeys.forEach(key => {
+			const state = subs[key];
 
-  // create and return component container
-  public registerComponent(instance, subs?): SubscriptionContainer {
-    if (typeof instance === 'function') {
-      // is this a callback based subscription?
-      let cC = new CallbackContainer(instance as Function, new Set(subs));
-      this.callbacks.add(cC);
-      return cC;
-      // is this a HOC based subscription
-    } else {
-      let cC = new ComponentContainer(instance);
-      this.components.add(cC);
-      instance.pulseComponentContainer = cC;
-      return cC;
-    }
-  }
+			// Add State to SubscriptionContainer Subs
+			subscriptionContainer.subs.add(state);
 
-  public mount(instance: any) {
-    if (!instance.pulseComponentContainer) return;
-    instance.pulseComponentContainer.ready = true;
-  }
-  /**
-   * Unsubscribe a component or callback
-   * @param instance - Either a CallbackContainer or a bound component instance
-   */
-  public unsubscribe(instance: any) {
-    const unsub = (cC: CallbackContainer | ComponentContainer) => {
-      cC.ready = false;
-      // remove component container from subs' dep
-      cC.subs.forEach(state => {
-        state.dep.subs.delete(cC);
-      });
-    };
-    if (instance instanceof CallbackContainer) unsub(instance);
-    else if (instance.pulseComponentContainer) unsub(instance.pulseComponentContainer);
-  }
+			// Add SubscriptionContainer to State Dependencies Subs
+			state.dep.subs.add(subscriptionContainer);
+
+			// Add state to prop
+			props[key] = state.value;
+		});
+
+		return {
+			subscriptionContainer: subscriptionContainer,
+			props: props
+		};
+	}
+
+	/**
+	 * Subscribe to Pulse state WITHOUT return object
+	 */
+	public subscribe(instance: any, subs: Array<State> = []): SubscriptionContainer {
+		let cC = this.registerComponent(instance, subs);
+		subs.forEach(state => {
+			if (state instanceof State) {
+				cC.subs.add(state);
+				state.dep.subs.add(cC);
+			}
+		});
+		return cC;
+	}
+
+	// create and return component container
+	public registerComponent(instance, subs?): SubscriptionContainer {
+		if (typeof instance === 'function') {
+			// is this a callback based subscription?
+			let cC = new CallbackContainer(instance as Function, new Set(subs));
+			this.callbacks.add(cC);
+			return cC;
+			// is this a HOC based subscription
+		} else {
+			let cC = new ComponentContainer(instance);
+			this.components.add(cC);
+			instance.pulseComponentContainer = cC;
+			return cC;
+		}
+	}
+
+	public mount(instance: any) {
+		if (!instance.pulseComponentContainer) return;
+		instance.pulseComponentContainer.ready = true;
+	}
+
+	/**
+	 * Unsubscribe a component or callback
+	 * @param instance - Either a CallbackContainer or a bound component instance
+	 */
+	public unsubscribe(instance: any) {
+		const unsub = (cC: CallbackContainer | ComponentContainer) => {
+			cC.ready = false;
+			// remove component container from subs' dep
+			cC.subs.forEach(state => {
+				state.dep.subs.delete(cC);
+			});
+		};
+		if (instance instanceof CallbackContainer) unsub(instance);
+		else if (instance.pulseComponentContainer) unsub(instance.pulseComponentContainer);
+	}
 }


### PR DESCRIPTION
## Description
Fixed the PulseHOC.. so that it is at least useable.
Still getting a waring 'Warning: Can't call setState on a component that is not yet mounted.'
but I think the current state is better than a not useable PulseHOC

How it works 
```
const App = (props: any) => {
    return (
        <div className="App">
            <header className="App-header">
                <img src={logo} className="App-logo" alt="logo"/>
                <p>
                    Edit <code>src/App.tsx</code> and save to reload.
                </p>
                <button onClick={() => setTimeout(() => {MY_STATE.set("Test2");}, 3000)}>
                    {props.myState}_{props.myState2}
                </button>
            </header>
        </div>
    );
}

export default PulseHOC(App, {myState: MY_STATE, myState2: MY_STATE_2});
```
You can also pass an array of States or just a State into the PulseHOC but than you can't access the 
current value of the State through props.. because (no naming for prop)

Note: A have a typo and with AgileHOC I mean PulseHOC ^^
