### PR TITLE
Add full typings to usePulse

### DIFF
--- a/examples/react-typescript/src/index.tsx
+++ b/examples/react-typescript/src/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './core';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./core";
 
-import './index.css';
-import App from './App';
+import "./index.css";
+import App from "./App";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/lib/integrations/react.integration.ts
+++ b/lib/integrations/react.integration.ts
@@ -92,11 +92,11 @@ export function PulseHOC(ReactComponent: any, deps?: Array<State> | { [key: stri
 type PulseHookArray<T> = { [K in keyof T]: T[K] extends State<infer U> ? U : never };
 type PulseHookResult<T> = T extends State<infer U> ? U : never;
 
+// array-argument syntax
+export function usePulse<X extends State<any>[]>(deps: X | [], pulseInstance?: Pulse): PulseHookArray<X>;
 // single-argument syntax
 export function usePulse<X extends State<any>>(deps: X, pulseInstance?: Pulse): PulseHookResult<X>;
-// array-argument syntax
-export function usePulse<X extends Array<State<any>>>(deps: X | [], pulseInstance?: Pulse): PulseHookArray<X>;
-// messy full syntax
+
 export function usePulse<X extends Array<State<any>>>(deps: X | [] | State, pulseInstance?: Pulse): PulseHookArray<X> | PulseHookResult<X> {
   // Normalize Dependencies
   let depsArray = normalizeDeps(deps) as PulseHookArray<X>;

--- a/lib/integrations/react.integration.ts
+++ b/lib/integrations/react.integration.ts
@@ -89,9 +89,15 @@ export function PulseHOC(ReactComponent: any, deps?: Array<State> | { [key: stri
   };
 }
 
-type PulseHookArray<X> = { [K in keyof X]: X[K] extends State<infer U> ? U : never };
+type PulseHookArray<T> = { [K in keyof T]: T[K] extends State<infer U> ? U : never };
+type PulseHookResult<T> = T extends State<infer U> ? U : never;
 
-export function usePulse<X extends Array<State<any>>>(deps: X | [] | State, pulseInstance?: Pulse): PulseHookArray<X> {
+// single-argument syntax
+export function usePulse<X extends State<any>>(deps: X, pulseInstance?: Pulse): PulseHookResult<X>;
+// array-argument syntax
+export function usePulse<X extends Array<State<any>>>(deps: X | [], pulseInstance?: Pulse): PulseHookArray<X>;
+// messy full syntax
+export function usePulse<X extends Array<State<any>>>(deps: X | [] | State, pulseInstance?: Pulse): PulseHookArray<X> | PulseHookResult<X> {
   // Normalize Dependencies
   let depsArray = normalizeDeps(deps) as PulseHookArray<X>;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
Typings are fully supported in usePulse now! It is inferred based on input State types. No explicit definitions needed!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
Tested with IntelliSense in VSCode. 

Reproducible:
```js
usePulse([null as State<string>, null as State<number>, null as State<string>, null as State<undefined>]);
// will have return type of [string, number, string, undefined] — NOT (string | number | undefined)[] — this is beautiful!```