### PR TITLE
Made usePulse more type-safe, add group support

### DIFF
--- a/lib/integrations/react.integration.ts
+++ b/lib/integrations/react.integration.ts
@@ -2,181 +2,184 @@ import Pulse from '..';
 import State from '../state';
 import { SubscriptionContainer } from '../sub';
 import { normalizeDeps, getPulseInstance } from '../utils';
+import Group from '../collection/group';
 
 export function PulseHOC(ReactComponent: any, deps?: Array<State> | { [key: string]: State } | State, pulseInstance?: Pulse) {
-  let depsArray: Array<State>;
-  let depsObject: { [key: string]: State };
+	let depsArray: Array<State>;
+	let depsObject: { [key: string]: State };
 
-  if (deps instanceof State || Array.isArray(deps)) {
-    // Normalize Dependencies
-    depsArray = normalizeDeps(deps || []);
+	if (deps instanceof State || Array.isArray(deps)) {
+		// Normalize Dependencies
+		depsArray = normalizeDeps(deps || []);
 
-    // Get Pulse Instance
-    if (!pulseInstance) {
-      if (depsArray.length > 0) {
-        const tempPulseInstance = getPulseInstance(depsArray[0]);
-        pulseInstance = tempPulseInstance || undefined;
-      } else {
-        console.warn("Pulse: Please don't pass an empty array!");
-      }
-    }
-  } else if (typeof deps === 'object') {
-    depsObject = deps;
+		// Get Pulse Instance
+		if (!pulseInstance) {
+			if (depsArray.length > 0) {
+				const tempPulseInstance = getPulseInstance(depsArray[0]);
+				pulseInstance = tempPulseInstance || undefined;
+			} else {
+				console.warn('Pulse: Please don\'t pass an empty array!');
+			}
+		}
+	} else if (typeof deps === 'object') {
+		depsObject = deps;
 
-    // Get Pulse Instance
-    if (!pulseInstance) {
-      const objectKeys = Object.keys(depsObject);
-      if (objectKeys.length > 0) {
-        const tempPulseInstance = getPulseInstance(depsObject[objectKeys[0]]);
-        pulseInstance = tempPulseInstance || undefined;
-      } else {
-        console.warn("Pulse: Please don't pass an empty object!");
-      }
-    }
-  } else {
-    console.error('Pulse: No Valid PulseHOC properties');
-    return ReactComponent;
-  }
+		// Get Pulse Instance
+		if (!pulseInstance) {
+			const objectKeys = Object.keys(depsObject);
+			if (objectKeys.length > 0) {
+				const tempPulseInstance = getPulseInstance(depsObject[objectKeys[0]]);
+				pulseInstance = tempPulseInstance || undefined;
+			} else {
+				console.warn('Pulse: Please don\'t pass an empty object!');
+			}
+		}
+	} else {
+		console.error('Pulse: No Valid PulseHOC properties');
+		return ReactComponent;
+	}
 
-  // Check if pulse Instance exists
-  if (!pulseInstance) {
-    console.error('Pulse: Failed to get Pulse Instance');
-    return ReactComponent;
-  }
+	// Check if pulse Instance exists
+	if (!pulseInstance) {
+		console.error('Pulse: Failed to get Pulse Instance');
+		return ReactComponent;
+	}
 
-  // Get React constructor
-  const React = pulseInstance.integration?.frameworkConstructor;
-  if (!React) {
-    console.error('Pulse: Failed to get Framework Constructor');
-    return ReactComponent;
-  }
+	// Get React constructor
+	const React = pulseInstance.integration?.frameworkConstructor;
+	if (!React) {
+		console.error('Pulse: Failed to get Framework Constructor');
+		return ReactComponent;
+	}
 
-  return class extends React.Component {
-    public componentContainer: SubscriptionContainer | null = null; // Will be set in registerSubscription (sub.ts)
+	return class extends React.Component {
+		public componentContainer: SubscriptionContainer | null = null; // Will be set in registerSubscription (sub.ts)
 
-    public updatedProps = this.props;
+		public updatedProps = this.props;
 
-    constructor(props: any) {
-      super(props);
+		constructor(props: any) {
+			super(props);
 
-      // Create HOC based Subscription with Array (Rerenders will here be caused via force Update)
-      if (depsArray) pulseInstance?.subController.subscribeWithSubsArray(this, depsArray);
+			// Create HOC based Subscription with Array (Rerenders will here be caused via force Update)
+			if (depsArray) pulseInstance?.subController.subscribeWithSubsArray(this, depsArray);
 
-      // Create HOC based Subscription with Object
-      if (depsObject) {
-        const response = pulseInstance?.subController.subscribeWithSubsObject(this, depsObject);
-        this.updatedProps = {
-          ...props,
-          ...response?.props
-        };
+			// Create HOC based Subscription with Object
+			if (depsObject) {
+				const response = pulseInstance?.subController.subscribeWithSubsObject(this, depsObject);
+				this.updatedProps = {
+					...props,
+					...response?.props
+				};
 
-        // Defines State for causing rerender (will be called in updateMethod)
-        this.state = depsObject;
-      }
-    }
+				// Defines State for causing rerender (will be called in updateMethod)
+				this.state = depsObject;
+			}
+		}
 
-    componentDidMount() {
-      if (pulseInstance?.config.waitForMount) pulseInstance?.subController.mount(this);
-    }
+		componentDidMount() {
+			if (pulseInstance?.config.waitForMount) pulseInstance?.subController.mount(this);
+		}
 
-    componentWillUnmount() {
-      pulseInstance?.subController.unsubscribe(this);
-    }
+		componentWillUnmount() {
+			pulseInstance?.subController.unsubscribe(this);
+		}
 
-    render() {
-      return React.createElement(ReactComponent, this.updatedProps);
-    }
-  };
+		render() {
+			return React.createElement(ReactComponent, this.updatedProps);
+		}
+	};
 }
 
-type PulseHookArray<T> = { [K in keyof T]: T[K] extends State<infer U> ? U : never };
-type PulseHookResult<T> = T extends State<infer U> ? U : never;
+// Array Type
+type PulseHookArrayType<T> = {
+	[K in keyof T]: T[K] extends Group<infer U> ? U[] :
+		T[K] extends State<infer U> ? U : never
+};
 
-// array-argument syntax
-export function usePulse<X extends State<any>[]>(deps: X | [], pulseInstance?: Pulse): PulseHookArray<X>;
-// single-argument syntax
-export function usePulse<X extends State<any>>(deps: X, pulseInstance?: Pulse): PulseHookResult<X>;
+// No Array Type
+type PulseHookType<T> = T extends Group<infer U> ? U[] :
+	T extends State<infer U> ? U : never;
 
-export function usePulse<X extends Array<State<any>>>(deps: X | [] | State, pulseInstance?: Pulse): PulseHookArray<X> | PulseHookResult<X> {
-  // Normalize Dependencies
-  let depsArray = normalizeDeps(deps) as PulseHookArray<X>;
+// Array
+export function usePulse<X extends Array<State>>(deps: X | [], pulseInstance?: Pulse): PulseHookArrayType<X>;
 
-  // Get Pulse Instance
-  if (!pulseInstance) {
-    const tempPulseInstance = getPulseInstance(depsArray[0]);
-    if (!tempPulseInstance) {
-      console.error('Pulse: Failed to get Pulse Instance');
-      return undefined;
-    }
-    pulseInstance = tempPulseInstance;
-  }
+// No Array
+export function usePulse<X extends State>(deps: X, pulseInstance?: Pulse): PulseHookType<X>;
 
-  // Get React constructor
-  const React = pulseInstance.integration?.frameworkConstructor;
-  if (!React) {
-    console.error('Pulse: Failed to get Framework Constructor');
-    return undefined;
-  }
+export function usePulse<X extends Array<State>, Y extends State>(deps: X | [] | Y, pulseInstance?: Pulse): PulseHookArrayType<X> | PulseHookType<Y> {
+	// Normalize Dependencies
+	let depsArray = normalizeDeps(deps) as Array<State>;
 
-  /* TODO: depsArrayFinal doesn't get used so idk if its necessary
-	let depsArrayFinal: Array<State> = [];
-	// this allows you to pass in a keyed object of States and subscribe to all  State within the first level of the object. Useful if you wish to subscribe a component to several State instances at the same time.
-	depsArray.forEach(dep => {
-		if (dep instanceof State) depsArrayFinal.push(dep);
-		else if (typeof dep === 'object')
-			for (let d in dep as keyedState) {
-				if ((dep[d] as any) instanceof State) depsArrayFinal.push(dep[d]);
-			}
-	});
-	 */
+	// Function which creates the return value
+	const getReturnValue = (depsArray: State[]): PulseHookArrayType<X> | PulseHookType<Y> => {
+		// Return Public Value of State
+		if (depsArray.length === 1 && !Array.isArray(deps))
+			return depsArray[0]?.getPublicValue() as PulseHookType<Y>;
 
-  // this is a trigger state used to force the component to re-render
-  const [_, set_] = React.useState({});
+		// Return Public Value of State in Array
+		return depsArray.map(dep => {
+			return dep.getPublicValue();
+		}) as PulseHookArrayType<X>;
+	};
 
-  React.useEffect(function () {
-    // Create a callback base subscription, Callback invokes re-render Trigger
-    const subscriptionContainer = pulseInstance?.subController.subscribeWithSubsArray(() => {
-      set_({});
-    }, depsArray);
+	// Get Pulse Instance
+	if (!pulseInstance) {
+		const tempPulseInstance = getPulseInstance(depsArray[0]);
+		if (!tempPulseInstance) {
+			console.error('Pulse: Failed to get Pulse Instance');
+			return getReturnValue(depsArray);
+		}
+		pulseInstance = tempPulseInstance;
+	}
 
-    // Unsubscribe on Unmount
-    return () => pulseInstance?.subController.unsubscribe(subscriptionContainer);
-  }, []);
+	// Get React constructor
+	const React = pulseInstance.integration?.frameworkConstructor;
+	if (!React) {
+		console.error('Pulse: Failed to get Framework Constructor');
+		return getReturnValue(depsArray);
+	}
 
-  // Return Public Value of State
-  if (!Array.isArray(deps) && depsArray.length === 1) return depsArray[0].getPublicValue();
+	// This is a trigger state used to force the component to re-render
+	const [_, set_] = React.useState({});
 
-  // Return Public Value of State in Array
-  return depsArray.map(dep => {
-    return dep.getPublicValue();
-  }) as PulseHookArray<X>;
+	React.useEffect(function() {
+		// Create a callback base subscription, Callback invokes re-render Trigger
+		const subscriptionContainer = pulseInstance?.subController.subscribeWithSubsArray(() => {
+			set_({});
+		}, depsArray);
+
+		// Unsubscribe on Unmount
+		return () => pulseInstance?.subController.unsubscribe(subscriptionContainer);
+	}, []);
+
+	return getReturnValue(depsArray);
 }
 
 export default {
-  name: 'react',
-  bind(pulseInstance: Pulse) {
-    //
-    // pulseInstance.React = (instance: any, deps: Array<State>) =>
-    //   PulseHOC(instance, deps, pulseInstance);
-    // // usePulse is able to get its context from the state passed in, below is redundant
-    // pulseInstance.usePulse = (deps: Array<State>) => usePulse(deps, pulseInstance);
-  },
-  updateMethod(componentInstance: any, updatedData: Object) {
-    // UpdatedData will be empty if the PulseHOC doesn't get an object as deps
+	name: 'react',
+	bind(pulseInstance: Pulse) {
+		//
+		// pulseInstance.React = (instance: any, deps: Array<State>) =>
+		//   PulseHOC(instance, deps, pulseInstance);
+		// // usePulse is able to get its context from the state passed in, below is redundant
+		// pulseInstance.usePulse = (deps: Array<State>) => usePulse(deps, pulseInstance);
+	},
+	updateMethod(componentInstance: any, updatedData: Object) {
+		// UpdatedData will be empty if the PulseHOC doesn't get an object as deps
 
-    if (Object.keys(updatedData).length !== 0) {
-      // Update Props
-      componentInstance.updatedProps = { ...componentInstance.updatedProps, ...updatedData };
+		if (Object.keys(updatedData).length !== 0) {
+			// Update Props
+			componentInstance.updatedProps = { ...componentInstance.updatedProps, ...updatedData };
 
-      // Set State (Rerender)
-      componentInstance.setState(updatedData);
-    } else {
-      // Force Update (Rerender)
-      componentInstance.forceUpdate();
-    }
-  },
-  onReady(pulseInstance: any | Pulse) {
-    // TODO is the onReady really necessary.. because I can't find a position where it get called
-    // pulseInstance.usePulse = (deps: Array<State> | State) => usePulse(deps, pulseInstance);
-  }
+			// Set State (Rerender)
+			componentInstance.setState(updatedData);
+		} else {
+			// Force Update (Rerender)
+			componentInstance.forceUpdate();
+		}
+	},
+	onReady(pulseInstance: any | Pulse) {
+		// TODO is the onReady really necessary.. because I can't find a position where it get called
+		// pulseInstance.usePulse = (deps: Array<State> | State) => usePulse(deps, pulseInstance);
+	}
 };

--- a/lib/integrations/react.integration.ts
+++ b/lib/integrations/react.integration.ts
@@ -5,100 +5,98 @@ import { normalizeDeps, getPulseInstance } from '../utils';
 import Group from '../collection/group';
 
 export function PulseHOC(ReactComponent: any, deps?: Array<State> | { [key: string]: State } | State, pulseInstance?: Pulse) {
-	let depsArray: Array<State>;
-	let depsObject: { [key: string]: State };
+  let depsArray: Array<State>;
+  let depsObject: { [key: string]: State };
 
-	if (deps instanceof State || Array.isArray(deps)) {
-		// Normalize Dependencies
-		depsArray = normalizeDeps(deps || []);
+  if (deps instanceof State || Array.isArray(deps)) {
+    // Normalize Dependencies
+    depsArray = normalizeDeps(deps || []);
 
-		// Get Pulse Instance
-		if (!pulseInstance) {
-			if (depsArray.length > 0) {
-				const tempPulseInstance = getPulseInstance(depsArray[0]);
-				pulseInstance = tempPulseInstance || undefined;
-			} else {
-				console.warn('Pulse: Please don\'t pass an empty array!');
-			}
-		}
-	} else if (typeof deps === 'object') {
-		depsObject = deps;
+    // Get Pulse Instance
+    if (!pulseInstance) {
+      if (depsArray.length > 0) {
+        const tempPulseInstance = getPulseInstance(depsArray[0]);
+        pulseInstance = tempPulseInstance || undefined;
+      } else {
+        console.warn("Pulse: Please don't pass an empty array!");
+      }
+    }
+  } else if (typeof deps === 'object') {
+    depsObject = deps;
 
-		// Get Pulse Instance
-		if (!pulseInstance) {
-			const objectKeys = Object.keys(depsObject);
-			if (objectKeys.length > 0) {
-				const tempPulseInstance = getPulseInstance(depsObject[objectKeys[0]]);
-				pulseInstance = tempPulseInstance || undefined;
-			} else {
-				console.warn('Pulse: Please don\'t pass an empty object!');
-			}
-		}
-	} else {
-		console.error('Pulse: No Valid PulseHOC properties');
-		return ReactComponent;
-	}
+    // Get Pulse Instance
+    if (!pulseInstance) {
+      const objectKeys = Object.keys(depsObject);
+      if (objectKeys.length > 0) {
+        const tempPulseInstance = getPulseInstance(depsObject[objectKeys[0]]);
+        pulseInstance = tempPulseInstance || undefined;
+      } else {
+        console.warn("Pulse: Please don't pass an empty object!");
+      }
+    }
+  } else {
+    console.error('Pulse: No Valid PulseHOC properties');
+    return ReactComponent;
+  }
 
-	// Check if pulse Instance exists
-	if (!pulseInstance) {
-		console.error('Pulse: Failed to get Pulse Instance');
-		return ReactComponent;
-	}
+  // Check if pulse Instance exists
+  if (!pulseInstance) {
+    console.error('Pulse: Failed to get Pulse Instance');
+    return ReactComponent;
+  }
 
-	// Get React constructor
-	const React = pulseInstance.integration?.frameworkConstructor;
-	if (!React) {
-		console.error('Pulse: Failed to get Framework Constructor');
-		return ReactComponent;
-	}
+  // Get React constructor
+  const React = pulseInstance.integration?.frameworkConstructor;
+  if (!React) {
+    console.error('Pulse: Failed to get Framework Constructor');
+    return ReactComponent;
+  }
 
-	return class extends React.Component {
-		public componentContainer: SubscriptionContainer | null = null; // Will be set in registerSubscription (sub.ts)
+  return class extends React.Component {
+    public componentContainer: SubscriptionContainer | null = null; // Will be set in registerSubscription (sub.ts)
 
-		public updatedProps = this.props;
+    public updatedProps = this.props;
 
-		constructor(props: any) {
-			super(props);
+    constructor(props: any) {
+      super(props);
 
-			// Create HOC based Subscription with Array (Rerenders will here be caused via force Update)
-			if (depsArray) pulseInstance?.subController.subscribeWithSubsArray(this, depsArray);
+      // Create HOC based Subscription with Array (Rerenders will here be caused via force Update)
+      if (depsArray) pulseInstance?.subController.subscribeWithSubsArray(this, depsArray);
 
-			// Create HOC based Subscription with Object
-			if (depsObject) {
-				const response = pulseInstance?.subController.subscribeWithSubsObject(this, depsObject);
-				this.updatedProps = {
-					...props,
-					...response?.props
-				};
+      // Create HOC based Subscription with Object
+      if (depsObject) {
+        const response = pulseInstance?.subController.subscribeWithSubsObject(this, depsObject);
+        this.updatedProps = {
+          ...props,
+          ...response?.props
+        };
 
-				// Defines State for causing rerender (will be called in updateMethod)
-				this.state = depsObject;
-			}
-		}
+        // Defines State for causing rerender (will be called in updateMethod)
+        this.state = depsObject;
+      }
+    }
 
-		componentDidMount() {
-			if (pulseInstance?.config.waitForMount) pulseInstance?.subController.mount(this);
-		}
+    componentDidMount() {
+      if (pulseInstance?.config.waitForMount) pulseInstance?.subController.mount(this);
+    }
 
-		componentWillUnmount() {
-			pulseInstance?.subController.unsubscribe(this);
-		}
+    componentWillUnmount() {
+      pulseInstance?.subController.unsubscribe(this);
+    }
 
-		render() {
-			return React.createElement(ReactComponent, this.updatedProps);
-		}
-	};
+    render() {
+      return React.createElement(ReactComponent, this.updatedProps);
+    }
+  };
 }
 
 // Array Type
 type PulseHookArrayType<T> = {
-	[K in keyof T]: T[K] extends Group<infer U> ? U[] :
-		T[K] extends State<infer U> ? U : never
+  [K in keyof T]: T[K] extends Group<infer U> ? U[] : T[K] extends State<infer U> ? U : never;
 };
 
 // No Array Type
-type PulseHookType<T> = T extends Group<infer U> ? U[] :
-	T extends State<infer U> ? U : never;
+type PulseHookType<T> = T extends Group<infer U> ? U[] : T extends State<infer U> ? U : never;
 
 // Array
 export function usePulse<X extends Array<State>>(deps: X | [], pulseInstance?: Pulse): PulseHookArrayType<X>;
@@ -107,79 +105,78 @@ export function usePulse<X extends Array<State>>(deps: X | [], pulseInstance?: P
 export function usePulse<X extends State>(deps: X, pulseInstance?: Pulse): PulseHookType<X>;
 
 export function usePulse<X extends Array<State>, Y extends State>(deps: X | [] | Y, pulseInstance?: Pulse): PulseHookArrayType<X> | PulseHookType<Y> {
-	// Normalize Dependencies
-	let depsArray = normalizeDeps(deps) as Array<State>;
+  // Normalize Dependencies
+  let depsArray = normalizeDeps(deps) as Array<State>;
 
-	// Function which creates the return value
-	const getReturnValue = (depsArray: State[]): PulseHookArrayType<X> | PulseHookType<Y> => {
-		// Return Public Value of State
-		if (depsArray.length === 1 && !Array.isArray(deps))
-			return depsArray[0]?.getPublicValue() as PulseHookType<Y>;
+  // Function which creates the return value
+  const getReturnValue = (depsArray: State[]): PulseHookArrayType<X> | PulseHookType<Y> => {
+    // Return Public Value of State
+    if (depsArray.length === 1 && !Array.isArray(deps)) return depsArray[0]?.getPublicValue() as PulseHookType<Y>;
 
-		// Return Public Value of State in Array
-		return depsArray.map(dep => {
-			return dep.getPublicValue();
-		}) as PulseHookArrayType<X>;
-	};
+    // Return Public Value of State in Array
+    return depsArray.map(dep => {
+      return dep.getPublicValue();
+    }) as PulseHookArrayType<X>;
+  };
 
-	// Get Pulse Instance
-	if (!pulseInstance) {
-		const tempPulseInstance = getPulseInstance(depsArray[0]);
-		if (!tempPulseInstance) {
-			console.error('Pulse: Failed to get Pulse Instance');
-			return getReturnValue(depsArray);
-		}
-		pulseInstance = tempPulseInstance;
-	}
+  // Get Pulse Instance
+  if (!pulseInstance) {
+    const tempPulseInstance = getPulseInstance(depsArray[0]);
+    if (!tempPulseInstance) {
+      console.error('Pulse: Failed to get Pulse Instance');
+      return getReturnValue(depsArray);
+    }
+    pulseInstance = tempPulseInstance;
+  }
 
-	// Get React constructor
-	const React = pulseInstance.integration?.frameworkConstructor;
-	if (!React) {
-		console.error('Pulse: Failed to get Framework Constructor');
-		return getReturnValue(depsArray);
-	}
+  // Get React constructor
+  const React = pulseInstance.integration?.frameworkConstructor;
+  if (!React) {
+    console.error('Pulse: Failed to get Framework Constructor');
+    return getReturnValue(depsArray);
+  }
 
-	// This is a trigger state used to force the component to re-render
-	const [_, set_] = React.useState({});
+  // This is a trigger state used to force the component to re-render
+  const [_, set_] = React.useState({});
 
-	React.useEffect(function() {
-		// Create a callback base subscription, Callback invokes re-render Trigger
-		const subscriptionContainer = pulseInstance?.subController.subscribeWithSubsArray(() => {
-			set_({});
-		}, depsArray);
+  React.useEffect(function () {
+    // Create a callback base subscription, Callback invokes re-render Trigger
+    const subscriptionContainer = pulseInstance?.subController.subscribeWithSubsArray(() => {
+      set_({});
+    }, depsArray);
 
-		// Unsubscribe on Unmount
-		return () => pulseInstance?.subController.unsubscribe(subscriptionContainer);
-	}, []);
+    // Unsubscribe on Unmount
+    return () => pulseInstance?.subController.unsubscribe(subscriptionContainer);
+  }, []);
 
-	return getReturnValue(depsArray);
+  return getReturnValue(depsArray);
 }
 
 export default {
-	name: 'react',
-	bind(pulseInstance: Pulse) {
-		//
-		// pulseInstance.React = (instance: any, deps: Array<State>) =>
-		//   PulseHOC(instance, deps, pulseInstance);
-		// // usePulse is able to get its context from the state passed in, below is redundant
-		// pulseInstance.usePulse = (deps: Array<State>) => usePulse(deps, pulseInstance);
-	},
-	updateMethod(componentInstance: any, updatedData: Object) {
-		// UpdatedData will be empty if the PulseHOC doesn't get an object as deps
+  name: 'react',
+  bind(pulseInstance: Pulse) {
+    //
+    // pulseInstance.React = (instance: any, deps: Array<State>) =>
+    //   PulseHOC(instance, deps, pulseInstance);
+    // // usePulse is able to get its context from the state passed in, below is redundant
+    // pulseInstance.usePulse = (deps: Array<State>) => usePulse(deps, pulseInstance);
+  },
+  updateMethod(componentInstance: any, updatedData: Object) {
+    // UpdatedData will be empty if the PulseHOC doesn't get an object as deps
 
-		if (Object.keys(updatedData).length !== 0) {
-			// Update Props
-			componentInstance.updatedProps = { ...componentInstance.updatedProps, ...updatedData };
+    if (Object.keys(updatedData).length !== 0) {
+      // Update Props
+      componentInstance.updatedProps = { ...componentInstance.updatedProps, ...updatedData };
 
-			// Set State (Rerender)
-			componentInstance.setState(updatedData);
-		} else {
-			// Force Update (Rerender)
-			componentInstance.forceUpdate();
-		}
-	},
-	onReady(pulseInstance: any | Pulse) {
-		// TODO is the onReady really necessary.. because I can't find a position where it get called
-		// pulseInstance.usePulse = (deps: Array<State> | State) => usePulse(deps, pulseInstance);
-	}
+      // Set State (Rerender)
+      componentInstance.setState(updatedData);
+    } else {
+      // Force Update (Rerender)
+      componentInstance.forceUpdate();
+    }
+  },
+  onReady(pulseInstance: any | Pulse) {
+    // TODO is the onReady really necessary.. because I can't find a position where it get called
+    // pulseInstance.usePulse = (deps: Array<State> | State) => usePulse(deps, pulseInstance);
+  }
 };


### PR DESCRIPTION
## Description
- Added Group support so that it doesn't return the group keys anymore
- Created a function in usePulse which returns the 'finalValue' and instead of returning undefined at some points, it now returns  the 'finalValue' with a warning

## How has that been tested?
In a dummy React Project

## Additional
Can you please create a file for webstorm and vs-code to import the code formatting from pulse
because my code formatting is always a little bit different which creates unnecessary changes
