### PR TITLE
Add commit hooks for autoformatting

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+git update-index -g

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.jsx" "*.ts" "*.tsx" "*.json" "*.vue" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+# Run prettier on all files that matched
+echo "$FILES" | xargs ./node_modules/.bin/prettier --write
+# Re-stage the prettified files
+echo "$FILES" | xargs git add
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "release": "yarn build && lerna publish --force-publish",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs --dest ./docs/dist/",
-    "now-build": "yarn run docs:build"
+    "now-build": "yarn run docs:build",
+    "postinstall": "git config --local core.hooksPath .githooks"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
This PR adds Git commit hooks that will enforce Prettier formatting. I've added it as a yarn postinstall script, so that after you run `yarn install` and install the relevant packages (specifically Prettier, in this case) the hook will be registered automatically

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->
This will prevent any unformatted files from being committed to the repository. This is local-only, so when I write the GitHub actions to automate releases, this would be something to look into on that end.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
I've tested it in the Notify repositories, and here as well. It all seems to work well, but could do with someone else's double-check!