### PR TITLE
Fix Date type being saved as an empty object

### DIFF
--- a/packages/pulse-core/lib/collection/collection.ts
+++ b/packages/pulse-core/lib/collection/collection.ts
@@ -203,9 +203,9 @@ export class Collection<DataType extends DefaultDataItem = DefaultDataItem, G ex
     return this.data[id as PrimaryKey];
   }
 
-  public getDataValue(id: PrimaryKey | State): DataType | {} {
+  public getDataValue(id: PrimaryKey | State): DataType | null {
     let data = this.findById(id).value;
-    if (!data) return {};
+    if (!data) return null;
     return this.computedFunc ? this.computedFunc(data) : data;
   }
 
@@ -381,7 +381,7 @@ export class Collection<DataType extends DefaultDataItem = DefaultDataItem, G ex
   public findById(id: PrimaryKey | State): Data<DataType> {
     return this.getData(id);
   }
-  public getValueById(id: PrimaryKey | State): DataType | {} {
+  public getValueById(id: PrimaryKey | State): DataType | null {
     return this.getDataValue(id);
   }
 }

--- a/packages/pulse-core/lib/utils.ts
+++ b/packages/pulse-core/lib/utils.ts
@@ -43,7 +43,7 @@ export function normalizeDeps(deps: Array<State> | State) {
 
 export const copy = val => {
   // ignore if primitive type
-  if (typeof val !== 'object') return val;
+  if (typeof val !== 'object' || val instanceof Date) return val;
 
   if (isWatchableObject(val)) val = { ...val };
   else if (Array.isArray(val)) val = [...val];


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
Add extra validation on `copy` function to verify if val is an instance of `Date`

## Related Issue
Fixes: #153 

Create an State of type Date
Set a new value to this state: `MY_STATE.set(new Date())`
The new value of this state is `{}`


## Context
#153 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->

Tested on Windows 10 with typescript 4.1.x, yarn 1.22.10 on 1 production project. I've edited manually inside `node_modules`
