### PR TITLE
feat(state): Add support to any js classes

### DIFF
--- a/packages/pulse-core/lib/utils.ts
+++ b/packages/pulse-core/lib/utils.ts
@@ -42,10 +42,13 @@ export function normalizeDeps(deps: Array<State> | State) {
 }
 
 export const copy = val => {
-  // ignore if not an Array or Object (will ignore if class instance)
-  const valConstructorName = Object.getPrototypeOf(val).constructor.name
-  if(['object', 'array'].includes(valConstructorName.toLowerCase())) return val
-
+  // cannot getPrototypeOf on `null` or `undefined`
+  if(typeof val !== 'undefined' && val !== null){
+    // ignore if not an array or object (will ignore if class instance)
+    const valConstructorName = Object.getPrototypeOf(val).constructor.name
+    if(!['object', 'array'].includes(valConstructorName.toLowerCase())) return val
+  }
+  
   if (isWatchableObject(val)) val = { ...val };
   else if (Array.isArray(val)) val = [...val];
 

--- a/packages/pulse-core/lib/utils.ts
+++ b/packages/pulse-core/lib/utils.ts
@@ -42,8 +42,9 @@ export function normalizeDeps(deps: Array<State> | State) {
 }
 
 export const copy = val => {
-  // ignore if primitive type
-  if (typeof val !== 'object' || val instanceof Date) return val;
+  // ignore if not an Array or Object (will ignore if class instance)
+  const valConstructorName = Object.getPrototypeOf(val).constructor.name
+  if(['object', 'array'].includes(valConstructorName.toLowerCase())) return val
 
   if (isWatchableObject(val)) val = { ...val };
   else if (Array.isArray(val)) val = [...val];


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
This makes class instances can be stored on state (without having to be inside an object)

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->

Currently, we can't save class instances on state without having to wrap inside an object. So classes like File, Date, etc will be stored as an empty object.
I've sent a PR that allows Date but it was a specific fix ( [context here](https://github.com/pulse-framework/pulse/pull/154#discussion_r554269198) ).
```ts
const FILE_STATE = App.State<File | null>(null)
const DATE_STATE = App.State<Date | null>(null)

DATE_STATE.set(new Date()); // DATE_STATE.value is now {} and not the current date
```

## How Has This Been Tested?
Tested on Windows 10 with typescript 4.1.x, yarn 1.22.10 on 1 production project. I've edited manually inside `node_modules`

![image](https://user-images.githubusercontent.com/38642628/104093929-87030600-526c-11eb-9a65-1ad2b54676cd.png)
(screenshot of saved state using a File class)
