### PR TITLE
fix Can't perform a React state update on an unmounted component

### DIFF
--- a/packages/pulse-react/lib/usePulse.ts
+++ b/packages/pulse-react/lib/usePulse.ts
@@ -29,15 +29,24 @@ export function usePulse<X extends Array<State<any>>>(deps: X | [] | State, puls
 
   // This is a trigger state used to force the component to re-render
   const [_, set_] = React.useState({});
+  // This removes the warning: `Can't perform a React state update on an unmounted component`
+  const isMountedRef = React.useRef(false);
 
   React.useEffect(function () {
+    isMountedRef.current = true;
+
     // Create a callback base subscription, Callback invokes re-render Trigger
     const subscriptionContainer = pulseInstance?.subController.subscribeWithSubsArray(() => {
-      set_({});
+      if (isMountedRef.current == true) {
+        set_({});
+      }
     }, depsArray);
 
     // Unsubscribe on Unmount
-    return () => pulseInstance?.subController.unsubscribe(subscriptionContainer);
+    return () => {
+      isMountedRef.current = false;
+      return pulseInstance?.subController.unsubscribe(subscriptionContainer);
+    }
   }, []);
 
   // Return public value of state


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
Add a ref to verify if the component is still mounted to prevent state update if the component is unmounted


## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->

Sometimes the usePulse hook updates the state when the component is unmounted

![image](https://user-images.githubusercontent.com/38642628/105615361-bc503d80-5dae-11eb-9e4a-f8971893c54b.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->

Edited the file on `node_modules` folder and tested on my production project